### PR TITLE
Update fbsimctl to v0.1.1

### DIFF
--- a/fbsimctl.rb
+++ b/fbsimctl.rb
@@ -1,15 +1,15 @@
 class Fbsimctl < Formula
   desc "A Powerful Command Line for Managing iOS Simulators"
   homepage "https://github.com/facebook/FBSimulatorControl/fbsimctl/README.md"
-  url "https://github.com/facebook/FBSimulatorControl/tarball/v0.1.0"
-  sha256 "8e3e74cd816185ca4328618931aff879ae0050f1740393214dfef943fcda109e"
+  url "https://github.com/facebook/FBSimulatorControl/tarball/v0.1.1"
+  sha256 "f971c28898457cc21d48542ddf6d269ee931190d702fe07083f4d2cddcb11fc4"
   head "https://github.com/facebook/FBSimulatorControl.git"
   
   depends_on "carthage"
   depends_on :xcode => ["7", :build]
 
   def install
-    system "./build.sh", "cli", "build", "#{libexec}" 
+    system "./build.sh", "fbsimctl", "build", "#{libexec}" 
     bin.install_symlink "#{libexec}/fbsimctl"
   end
 


### PR DESCRIPTION
The build subcommand changed since a [change to the build script was landed](https://github.com/facebook/FBSimulatorControl/commit/f3c5e75ab133e265cda1314b087d8e9bb2c7007b). I created a new tag, so that we can update the formula accordingly.

Output:
```
$ brew install fbsimctl
==> Installing fbsimctl from lawrencelomax/fb
==> Downloading https://github.com/facebook/FBSimulatorControl/tarball/v0.1.1
Already downloaded: /Users/lawrencelomax/Library/Caches/Homebrew/fbsimctl-0.1.1.1
==> ./build.sh fbsimctl build /usr/local/Cellar/fbsimctl/0.1.1/libexec
🍺  /usr/local/Cellar/fbsimctl/0.1.1: 573 files, 49.8M, built in 56 seconds
```