### PR TITLE
fbthrift-compiler: fix build

### DIFF
--- a/fbthrift-compiler.rb
+++ b/fbthrift-compiler.rb
@@ -42,7 +42,9 @@ class FbthriftCompiler < Formula
           "--disable-silent-rules",
           "--prefix=#{prefix}",
           "--without-python", # see patch comment above
-          "--without-cpp" # see patch comment above
+          "--without-cpp", # see patch comment above
+          "--with-boost=#{HOMEBREW_PREFIX}",
+          "--with-folly=#{HOMEBREW_PREFIX}"
 
       system "make", "install"
     end


### PR DESCRIPTION
Summary:

Need to specify `--with-folly` and `--with-boost` in order to get it to
build/run correctly in some environments. I am not sure when/why they are required.

Test plan:

`brew install --HEAD fbthrift-compiler` on a clean homebrew. Thrift builds/runs.