### PR TITLE
Bump fbsimctl to v0.2.2

### DIFF
--- a/fbsimctl.rb
+++ b/fbsimctl.rb
@@ -1,8 +1,8 @@
 class Fbsimctl < Formula
   desc "A Powerful Command Line for Managing iOS Simulators"
   homepage "https://github.com/facebook/FBSimulatorControl/fbsimctl/README.md"
-  url "https://github.com/facebook/FBSimulatorControl/tarball/v0.2.0"
-  sha256 "872b8b98427527cad16c8f235ae987fc2fad3be00dc344632de489a5cce0f620"
+  url "https://github.com/facebook/FBSimulatorControl/tarball/v0.2.2"
+  sha256 "119718ee8a0611d087f46dda1603c6622b075270ef47889c2b16d781391e7c2b"
   head "https://github.com/facebook/FBSimulatorControl.git"
 
   depends_on "carthage"


### PR DESCRIPTION
Bumping version number. This also adds the `fbsimrecord` wrapper script, which will be installed as a binary to the cellar.

cc @asm89 @marekcirkos
