### PR TITLE
Bump fbsimctl to v0.2.3

### DIFF
--- a/fbsimctl.rb
+++ b/fbsimctl.rb
@@ -1,12 +1,12 @@
 class Fbsimctl < Formula
   desc "A Powerful Command Line for Managing iOS Simulators"
   homepage "https://github.com/facebook/FBSimulatorControl/fbsimctl/README.md"
-  url "https://github.com/facebook/FBSimulatorControl/tarball/v0.2.2"
-  sha256 "119718ee8a0611d087f46dda1603c6622b075270ef47889c2b16d781391e7c2b"
+  url "https://github.com/facebook/FBSimulatorControl/tarball/v0.2.3"
+  sha256 "7f5a6853fc80a174940b686c9d448e240c724c095d884dd517d06ca4b73c3e6d"
   head "https://github.com/facebook/FBSimulatorControl.git"
 
   depends_on "carthage"
-  depends_on :xcode => ["8", :build]
+  depends_on :xcode => ["8.1", :build]
 
   def install
     system "./build.sh", "fbsimctl", "build", prefix


### PR DESCRIPTION
Bumps to a newer version, requiring Xcode 8.1.

```brew install fbsimctl
==> Installing fbsimctl from lawrencelomax/fb
==> Downloading https://github.com/facebook/FBSimulatorControl/tarball/v0.2.3
Already downloaded: /Users/lawrencelomax/Library/Caches/Homebrew/fbsimctl-0.2.3.3
==> ./build.sh fbsimctl build /usr/local/Cellar/fbsimctl/0.2.3
🍺  /usr/local/Cellar/fbsimctl/0.2.3: 243 files, 16M, built in 32 seconds```