### PR TITLE
fbsimctl v0.4.0

### DIFF
--- a/fbsimctl.rb
+++ b/fbsimctl.rb
@@ -1,12 +1,12 @@
 class Fbsimctl < Formula
   desc "A Powerful Command Line for Managing iOS Simulators"
   homepage "https://github.com/facebook/FBSimulatorControl/fbsimctl/README.md"
-  url "https://github.com/facebook/FBSimulatorControl/tarball/v0.3.0"
-  sha256 "cd024f4e96e1ab2a82ec25d13bc385484d66904a21e59eb03cdddd41fa8fe4b9"
+  url "https://github.com/facebook/FBSimulatorControl/tarball/v0.4.0"
+  sha256 "5d2ed56047f2b4b3f5f0804545c6730876be2372a834e70bc88a4cb9d4253e19"
   head "https://github.com/facebook/FBSimulatorControl.git"
 
   depends_on "carthage"
-  depends_on :xcode => ["8.1", :build]
+  depends_on :xcode => ["8.2", :build]
 
   def install
     system "./build.sh", "fbsimctl", "build", prefix


### PR DESCRIPTION
Bumping as there are breaking changes to the API.

```
brew install fbsimctl
==> Installing fbsimctl from lawrencelomax/fb
==> Downloading https://github.com/facebook/FBSimulatorControl/tarball/v0.4.0
Already downloaded: /Users/lawrencelomax/Library/Caches/Homebrew/fbsimctl-0.4.0.0
==> ./build.sh fbsimctl build /usr/local/Cellar/fbsimctl/0.4.0
🍺  /usr/local/Cellar/fbsimctl/0.4.0: 251 files, 16.2MB, built in 36 seconds
```