### PR TITLE
Change squashfuse to squashfs in xar.rb

### DIFF
--- a/xar.rb
+++ b/xar.rb
@@ -7,7 +7,7 @@ class Xar < Formula
 
   depends_on "cmake" => :build
   depends_on :osxfuse
-  depends_on "squashfuse"
+  depends_on "squashfs"
 
   def install
     system "cmake", ".", *std_cmake_args


### PR DESCRIPTION
`squashfuse` isn't  available as a homebrew formula on OSX, but `squashfs` is.