### PR TITLE
Add build timestamp and cleanup buck recipe

### DIFF
--- a/buck.rb
+++ b/buck.rb
@@ -2,6 +2,7 @@ require "open3"
 
 class Buck < Formula
   @@buck_version = "2018.03.26.01"
+  @@buck_release_time = "1522099141"
   desc "The Buck build system"
   homepage "https://buckbuild.com/"
   head "https://github.com/facebook/buck.git"
@@ -19,24 +20,17 @@ class Buck < Formula
   depends_on "ant"
 
   def install
+    ENV["BUCK_RELEASE"] = @@buck_version
+    ENV["BUCK_RELEASE_TIMESTAMP"] = @@buck_release_time
     # First, bootstrap the build by building Buck with Apache Ant.
+    ohai "Bootstrapping buck with ant"
     system "ant"
     # Mark the build as successful.
     File.open("build/successful-build", "w") {}
     # Now, build the Buck PEX archive with the Buck bootstrap.
-    system "./bin/buck", "build", "buck"
+    ohai "Building buck with buck"
     mkdir_p "#{bin}"
-    ohai "Finding PEX archive..."
-    stdout, stderr, status = Open3.capture3("./bin/buck", "targets", "--show_output", "buck")
-    if status == 0
-      stdout.chomp!
-      _, path = stdout.split(" ", 2)
-      ohai "Installing buck in #{bin}/buck..."
-      cp(path, "#{bin}/buck", :preserve => true)
-      ohai "Done."
-    else
-      onoe "Could not find location of built buck: " + stderr
-    end
+    system "./bin/buck", "build", "buck", "--out", "#{bin}/buck"
   end
 
   test do


### PR DESCRIPTION
Summary:

- Add a build timestamp to allow overriding the build metadata
- Export version / timestamp as env vars for a follow buck diff
- Remove some extra commands, and just use buck build --out instead

Test Plan:

Ran env > /tmp/env_file, verified that env vars were set properly

```
$ brew install --build-bottle buck
==> Installing buck from facebook/fb
==> Downloading https://api.github.com/repos/facebook/buck/tarball/v2018.03.26.01
Already downloaded: /Users/pjameson/Library/Caches/Homebrew/buck-2018.03.26.01.01
==> Bootstrapping buck with ant
==> ant
==> Building buck with buck
==> ./bin/buck build buck --out /usr/local/Cellar/buck/2018.03.26.01/bin/buck
==> Not running post_install as we're building a bottle
You can run it manually using `brew postinstall facebook/fb/buck`
==> Summary
🍺  /usr/local/Cellar/buck/2018.03.26.01: 5 files, 86.5MB, built in 2 minutes 54 seconds

$ find /usr/local/Cellar/buck/2018.03.26.01/
/usr/local/Cellar/buck/2018.03.26.01/
/usr/local/Cellar/buck/2018.03.26.01//INSTALL_RECEIPT.json
/usr/local/Cellar/buck/2018.03.26.01//LICENSE
/usr/local/Cellar/buck/2018.03.26.01//bin
/usr/local/Cellar/buck/2018.03.26.01//bin/buck
/usr/local/Cellar/buck/2018.03.26.01//.brew
/usr/local/Cellar/buck/2018.03.26.01//.brew/buck.rb
/usr/local/Cellar/buck/2018.03.26.01//README.md

$ /usr/local/Cellar/buck/2018.03.26.01//bin/buck --help
Description:
  Buck build tool
....
Options:
 --flagfile FILE : File to read command line arguments from.
 --help (-h)     : Shows this screen and exits.
 --version (-V)  : Show version number.
$

```