### PR TITLE
Add squashfuse formula

### DIFF
--- a/squashfuse.rb
+++ b/squashfuse.rb
@@ -1,0 +1,47 @@
+class Squashfuse < Formula
+  desc "FUSE filesystem to mount squashfs archives"
+  homepage "https://github.com/vasi/squashfuse"
+  url "https://github.com/vasi/squashfuse/releases/download/0.1.103/squashfuse-0.1.103.tar.gz"
+  sha256 "42d4dfd17ed186745117cfd427023eb81effff3832bab09067823492b6b982e7"
+
+  depends_on "pkg-config" => :build
+
+  depends_on "lz4"
+  depends_on "lzo"
+  depends_on :osxfuse
+  depends_on "squashfs"
+  depends_on "xz"
+  depends_on "zstd"
+
+  def install
+    configure_args = [
+      "--disable-dependency-tracking",
+      "--disable-silent-rules",
+      "--prefix=#{prefix}",
+    ]
+
+    system "./configure", *configure_args
+    system "make", "install"
+  end
+
+  # Unfortunately, making/testing a squash mount requires sudo priviledges, so
+  # just test that squashfuse execs for now.
+  test do
+    def pid_exists?(pid)
+      Process.kill 0, pid
+      true
+    rescue Errno::ESRCH
+      false
+    end
+
+    begin
+      pid = fork { exec "squashfuse", "--help" }
+      _, status = Process.wait2 pid
+
+      # Returns 254 after running --help.
+      assert_equal 254, status.exitstatus
+    ensure
+      Process.kill "TERM", pid if pid_exists? pid
+    end
+  end
+end


### PR DESCRIPTION
This is a dep on the xar formula in this repo. We need this to be in the
tap to unblock xar installation.

This is a copy of the change I submitted to upstream homebrew-core, but in case they don't accept in time, it will at least be in our tap (where the main xar formula is anyway).

Testing install:
```
$ brew install xar
==> Installing xar from facebook/fb
==> Installing dependencies for facebook/fb/xar: squashfuse
==> Installing facebook/fb/xar dependency: squashfuse
==> Downloading https://github.com/vasi/squashfuse/archive/0.1.103.tar.gz
==> Downloading from https://codeload.github.com/vasi/squashfuse/tar.gz/0.1.103
######################################################################## 100.0%
==> ./autogen.sh
==> ./configure --disable-silent-rules --prefix=/usr/local/Cellar/squashfuse/0.1.103 --with-lz4=/usr/local --with-lz0=/usr/local --with-xz=/usr/local --with-zlib=/usr/local --with-==> make install
🍺  /usr/local/Cellar/squashfuse/0.1.103: 18 files, 180.5KB, built in 30 seconds
==> Installing facebook/fb/xar
==> Downloading https://github.com/facebook/xar/archive/master.zip
```