### PR TITLE
XAR: Bump release

### DIFF
--- a/xar.rb
+++ b/xar.rb
@@ -1,9 +1,8 @@
 class Xar < Formula
   desc "The eXecutable Archive Format"
   homepage "https://github.com/facebookincubator/xar"
-  url "https://github.com/facebookincubator/xar/archive/master.zip"
-  version "0.0.1"
-  sha256 "c94bb886ad9bd91ff3d1a65c58b7954b44b64d84ba2abc133426db93a112b9ef"
+  url "https://github.com/facebookincubator/xar/archive/v18.07.12.tar.gz"
+  sha256 "517414281f02af5c304cb87f08c855e3e5ca812580ff94ff48972d68ec75558d"
 
   depends_on "cmake" => :build
   depends_on :osxfuse
@@ -15,6 +14,6 @@ class Xar < Formula
   end
 
   test do
-    system "xarexec_fuse --help"
+    system "xarexec_fuse", "--help"
   end
 end


### PR DESCRIPTION
First XAR release was cut (18.07.12).

Test:
```
$ brew install xar
==> Installing xar from facebook/fb
==> Downloading https://github.com/facebookincubator/xar/archive/v18.07.12.tar.gz
Already downloaded: /Users/skarlage/Library/Caches/Homebrew/xar-18.07.12.tar.gz
==> cmake . -DCMAKE_C_FLAGS_RELEASE=-DNDEBUG -DCMAKE_CXX_FLAGS_RELEASE=-DNDEBUG -DCMAKE_INSTALL_PREFIX=/usr/local/Cellar/xar/18.07.12 -DCMAKE_BUILD_TYPE=Release -DCMAKE_FIND_FRAMEWO==> make install
🍺  /usr/local/Cellar/xar/18.07.12: 5 files, 80.5KB, built in 7 seconds
[15:14:21] skarlage@skarlage-mbp:~/wa
$ xarexec_fuse -h
Usage: xarexec [-m|-n] /path/to/file.xar
Options:
     -m: mount and print mountpoint, do not execute payload
     -n: print the mountpoint but don't mount
```

Also make formula pass with `brew audit --strict --online`.