### PR TITLE
Remove unneeded or_later in buck formula

### DIFF
--- a/buck.rb
+++ b/buck.rb
@@ -13,7 +13,7 @@ class Buck < Formula
   bottle do
     root_url "https://github.com/facebook/buck/releases/download/v#{@@buck_version}"
     cellar :any_skip_relocation
-    sha256 "2b777c70022440424d82f2fa6c893ba8fb4173971a1efcc40ab14e68558121b0" => :yosemite_or_later
+    sha256 "2b777c70022440424d82f2fa6c893ba8fb4173971a1efcc40ab14e68558121b0" => :yosemite
   end
 
   depends_on :java => "1.8+"


### PR DESCRIPTION
In the last week or two, I started noticing these warnings when I would run `brew cleanup`, and it seemed this repo was the culprit:

```
➜  ~ brew cleanup
Warning: Calling `or_later` bottles is deprecated! Use bottles without `or_later` (or_later is implied now) instead.
Warning: Calling `or_later` bottles is deprecated! Use bottles without `or_later` (or_later is implied now) instead.
Warning: Calling `or_later` bottles is deprecated! Use bottles without `or_later` (or_later is implied now) instead.
Warning: Calling `or_later` bottles is deprecated! Use bottles without `or_later` (or_later is implied now) instead.
```

This fix made that warning go away.
