### PR TITLE
Make compliant to Homebrew’s coding standard

### DIFF
--- a/buck.rb
+++ b/buck.rb
@@ -1,5 +1,3 @@
-require "open3"
-
 class Buck < Formula
   BUCK_VERSION = "2018.10.29.01".freeze
   BUCK_RELEASE_TIMESTAMP = "1540624817".freeze
@@ -27,7 +25,7 @@ class Buck < Formula
     ohai "Bootstrapping buck with ant"
     system "ant"
     # Mark the build as successful.
-    File.open("ant-out/successful-build", "w") {}
+    touch "ant-out/successful-build"
     # Now, build the Buck PEX archive with the Buck bootstrap.
     ohai "Building buck with buck"
     mkdir_p bin
@@ -50,10 +48,9 @@ class Buck < Formula
     (testpath/"BUCK").write("cxx_binary(name = 'foo', srcs = ['foo.c'])")
     (testpath/"foo.c").write("#include <stdio.h>\nint main(int argc, char **argv) { printf(\"Hello world!\\n\"); }\n")
     ohai "Building and running C binary..."
-    stdout, _, status = Open3.capture3("#{bin}/buck", "run", ":foo")
-    stdout.chomp!
+    stdout = shell_output("#{bin}/buck run :foo").chomp
     ohai "Got output from binary: " + stdout
-    assert_equal 0, status
+    assert_equal 0, $CHILD_STATUS.exitstatus
     assert_equal "Hello world!", stdout
     ohai "Test complete."
   end

--- a/buck.rb
+++ b/buck.rb
@@ -17,11 +17,7 @@ class Buck < Formula
   depends_on :java => "1.8+"
 
   def install
-    # https://github.com/Homebrew/brew/pull/4552 stopped extracting stuff for us
-    if File.exist?("v#{version}")
-      ohai "Homebrew didn't extract the source tarball. Extracting..."
-      system("tar", "--strip-components", "1", "-xf", "v#{version}")
-    end
+    # First, bootstrap the build by building Buck with Apache Ant.
     ohai "Bootstrapping buck with ant"
     system "ant"
     # Mark the build as successful.

--- a/buck.rb
+++ b/buck.rb
@@ -50,7 +50,6 @@ class Buck < Formula
     ohai "Building and running C binary..."
     stdout = shell_output("#{bin}/buck run :foo").chomp
     ohai "Got output from binary: " + stdout
-    assert_equal 0, $CHILD_STATUS.exitstatus
     assert_equal "Hello world!", stdout
     ohai "Test complete."
   end


### PR DESCRIPTION
This PR aims to get the Buck formula in top shape according to Homebrew’s established [coding style](https://github.com/Homebrew/brew/blob/master/docs/Formula-Cookbook.md) so that both the `brew audit buck` and `brew style buck` commands will no longer return warnings.

The PR also removes a workaround that is no longer needed, and loses a few redundant lines of code. (See commit messages for details.)

Note that currently, Buck [errors out](https://github.com/facebook/buck/issues/2037) at runtime if Java 11 is installed. Running `brew install -s facebook/fb/buck` will fail [in a similar way at build time](https://github.com/facebook/buck/issues/2037#issuecomment-441990921).
I’m currently working on a fix for the formula but I thought I’d submit the style PR first.
