### PR TITLE
Fix regression regarding `brew audit`

### DIFF
--- a/buck.rb
+++ b/buck.rb
@@ -3,7 +3,7 @@ class Buck < Formula
   BUCK_RELEASE_TIMESTAMP = "1547139889".freeze
   desc "The Buck build system"
   homepage "https://buckbuild.com/"
-  url "https://api.github.com/repos/facebook/buck/tarball/v2019.01.10.01"
+  url "https://github.com/facebook/buck/archive/v#{BUCK_VERSION}.tar.gz"
   sha256 "9b0ebbf0c5f4e5d83a6ec4efd319cdd062f1103b92b06b5954fcf142d6de14e7"
   head "https://github.com/facebook/buck.git"
 


### PR DESCRIPTION
This fixes a regression which was fixed earlier in #32.
(Some automated release process appears to have re-introduced the issue today.)

Any chance that this fix be applied to your release scripts, too?

I’d recommend to keep the Buck formula compliant to `brew audit`. That would increase Buck’s chance to find its way into Homebrew’s core repository eventually, which would enable any formula to have their artifacts built with Buck.
