### PR TITLE
[buck] Force java version to 1.8 to handle java_home exec in homebrew

### DIFF
--- a/buck.rb
+++ b/buck.rb
@@ -14,7 +14,7 @@ class Buck < Formula
   end
 
   depends_on "ant"
-  depends_on :java => "1.8+"
+  depends_on :java => "1.8"
 
   def install
     # First, bootstrap the build by building Buck with Apache Ant.


### PR DESCRIPTION
Currently homebrew ignores java env vars on osx and forces the latest version to be used. While we are most of the way there for java 11 compat, for now force 1.8 to be used when building a bottle. 