### PR TITLE
fix depends_on :java is deprecated

### DIFF
--- a/buck.rb
+++ b/buck.rb
@@ -16,7 +16,7 @@ class Buck < Formula
   end
 
   depends_on "ant@1.9"
-  depends_on java: "1.8"
+  depends_on "openjdk"
 
   def install
     # First, bootstrap the build by building Buck with Apache Ant.

--- a/buck.rb
+++ b/buck.rb
@@ -16,7 +16,7 @@ class Buck < Formula
   end
 
   depends_on "ant@1.9"
-  depends_on "openjdk"
+  depends_on "openjdk@8"
 
   def install
     # First, bootstrap the build by building Buck with Apache Ant.

--- a/buck.rb
+++ b/buck.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Buck < Formula
-  BUCK_VERSION = "2020.10.21.01"
+  BUCK_VERSION = "2020.10.21.01_1"
   BUCK_RELEASE_TIMESTAMP = "1603230110"
   desc "Facebook's Buck build system"
   homepage "https://buckbuild.com/"


### PR DESCRIPTION
fixes **depends_on :java** is deprecated warning

```
Warning: Calling depends_on :java is deprecated! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.
Please report this issue to the facebook/fb tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/facebook/homebrew-fb/buck.rb:19
```