### PR TITLE
Fix depends on java is disabled

### DIFF
--- a/buck.rb
+++ b/buck.rb
@@ -16,7 +16,7 @@ class Buck < Formula
   end
 
   depends_on "ant@1.9"
-  depends_on java: "1.8"
+  depends_on "openjdk@8"
 
   def install
     # First, bootstrap the build by building Buck with Apache Ant.


### PR DESCRIPTION
```
Error: Invalid formula: /opt/homebrew/Library/Taps/facebook/homebrew-fb/buck.rb
buck: Calling depends_on :java is disabled! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.
# frozen_string_literal: true
Please report this issue to the facebook/fb tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/facebook/homebrew-fb/buck.rb:19
```