### PR TITLE
Fix asset URL by introducing proper revision annotation

### DIFF
--- a/buck.rb
+++ b/buck.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 class Buck < Formula
-  BUCK_VERSION = "2020.10.21.01_1"
+  BUCK_VERSION = "2020.10.21.01"
   BUCK_RELEASE_TIMESTAMP = "1603230110"
   desc "Facebook's Buck build system"
   homepage "https://buckbuild.com/"
   url "https://github.com/facebook/buck/archive/v#{BUCK_VERSION}.tar.gz"
   sha256 "b0db2a134c8e11937de9610ed61d80adfde4e68f7661f54749d6340336f04f78"
+  revision 1
   head "https://github.com/facebook/buck.git"
 
   bottle do


### PR DESCRIPTION
The BUCK_VERSION variable is used in the asset URL interpolation and the installation script.
Changing it will lead to wrong URL and false build info.
Thus reverting the changes done in dulmandakh/homebrew-fb@500a076c0f38d1700225787c5685bcf9e7477777 , and add a [revision](https://docs.brew.sh/Formula-Cookbook#formulae-revisions) annotation instead.