### PR TITLE
Fix source and bottle URL

### DIFF
--- a/buck.rb
+++ b/buck.rb
@@ -12,8 +12,9 @@ class Buck < Formula
   desc "Facebook's Buck build system"
   homepage "https://buckbuild.com/"
   url "https://github.com/facebook/buck/archive/v#{BUCK_VERSION}.tar.gz"
+  sha256 "c89e86e8a8355f6bc921afe8218a3cb1138c896a97e3168cf5dd220b07d8d1b5"
   license "Apache-2.0"
-  revision 1
+  revision 0
   head "https://github.com/facebook/buck.git"
 
   bottle do


### PR DESCRIPTION
The previous formula needs a revision tag because it's patched, which the current latest release is not.
It affects the URL used to download assets like source and bottle.

Currently homebrew cannot download the bottle because the bottle URL is not valid.