### PR TITLE
Force use Java 8 to build and run Buck

### DIFF
--- a/buck.rb
+++ b/buck.rb
@@ -21,6 +21,7 @@ class Buck < Formula
 
   def install
     # First, bootstrap the build by building Buck with Apache Ant.
+    ENV["JAVA_HOME"] = Formula["openjdk@8"].opt_libexec/"openjdk.jdk/Contents/Home"
     ant_path = `"#{HOMEBREW_PREFIX}"/bin/brew --prefix ant@1.9`
     ant_1_9 = ant_path.strip + "/bin/ant"
     ohai "Bootstrapping buck with anti using " + ant_1_9
@@ -45,6 +46,8 @@ class Buck < Formula
       "#{bin}/buck",
       "buck",
     )
+    bin.env_script_all_files(libexec/"bin",
+      JAVA_HOME: Formula["openjdk@8"].opt_libexec/"openjdk.jdk/Contents/Home")
   end
 
   test do


### PR DESCRIPTION
This pins `JAVA_HOME` to the brewed openjdk formula when building and running Buck.
Otherwise, having any Java version greater than 8 installed alongside openjdk@8 would cause errors both at build time (as Homebrew’s build environment clears most environment variables) and when invoking Buck (unless the user happens to have `JAVA_HOME` set to Java 8).

Pinning `JAVA_HOME` to `openjdk@8`, which is guaranteed to be installed, fixes the issue.
