### PR TITLE
Fix xar.rb syntax

### DIFF
--- a/xar.rb
+++ b/xar.rb
@@ -5,7 +5,7 @@ class Xar < Formula
   sha256 "517414281f02af5c304cb87f08c855e3e5ca812580ff94ff48972d68ec75558d"
 
   depends_on "cmake" => :build
-  depends_on :osxfuse
+  depends_on "osxfuse"
   depends_on "squashfuse"
 
   def install


### PR DESCRIPTION
```
==> Tapping facebook/fb
Cloning into '/usr/local/Homebrew/Library/Taps/facebook/homebrew-fb'...
remote: Enumerating objects: 9, done.
remote: Counting objects: 100% (9/9), done.
remote: Compressing objects: 100% (7/7), done.
remote: Total 342 (delta 4), reused 4 (delta 2), pack-reused 333
Receiving objects: 100% (342/342), 5.44 MiB | 3.54 MiB/s, done.
Resolving deltas: 100% (185/185), done.
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/facebook/homebrew-fb/xar.rb
xar: Calling depends_on :osxfuse is disabled! There is no replacement.
Please report this issue to the facebook/fb tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/facebook/homebrew-fb/xar.rb:8
```